### PR TITLE
Fix moveNode test for updated API

### DIFF
--- a/client/utils/elkOperations.test.ts
+++ b/client/utils/elkOperations.test.ts
@@ -194,7 +194,8 @@ describe("ELK JS Layout Operations", () => {
             const sourceParentId = "lambda";
             const targetParentId = "openai";
 
-            layout = moveNode(nodeId, sourceParentId, targetParentId, layout);
+            // move the node to the new parent
+            layout = moveNode(nodeId, targetParentId, layout);
             saveGraphToFile(layout, `move_${nodeId}_from_${sourceParentId}_to_${targetParentId}.json`);
             
             // Check node exists in target parent


### PR DESCRIPTION
## Summary
- fix the test for `moveNode` to match the current function signature

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f544e01d0832ead8836834cb3e217